### PR TITLE
Add Generation V Sturdy

### DIFF
--- a/src/battle/battle_controller.c
+++ b/src/battle/battle_controller.c
@@ -3391,6 +3391,12 @@ static void BattleController_UpdateHP(BattleSystem *battleSys, BattleContext *ba
             if (itemEffect == HOLD_EFFECT_ENDURE && DEFENDING_MON.curHP == DEFENDING_MON.maxHP) {
                 DEFENDER_SELF_TURN_FLAGS.focusItemActivated = TRUE;
             }
+
+            // need to check if the attacker ignores sturdy
+            if (Battler_Ability(battleCtx, battleCtx->defender) == ABILITY_STURDY
+                && DEFENDING_MON.curHP == DEFENDING_MON.maxHP) {
+                DEFENDER_TURN_FLAGS.enduring = TRUE;
+            }
         }
 
         if ((DEFENDER_TURN_FLAGS.enduring || DEFENDER_SELF_TURN_FLAGS.focusItemActivated)

--- a/src/battle/battle_controller.c
+++ b/src/battle/battle_controller.c
@@ -3392,8 +3392,7 @@ static void BattleController_UpdateHP(BattleSystem *battleSys, BattleContext *ba
                 DEFENDER_SELF_TURN_FLAGS.focusItemActivated = TRUE;
             }
 
-            // need to check if the attacker ignores sturdy
-            if (Battler_Ability(battleCtx, battleCtx->defender) == ABILITY_STURDY
+            if (Battler_IgnorableAbility(battleCtx, battleCtx->attacker, battleCtx->defender, ABILITY_STURDY) == TRUE
                 && DEFENDING_MON.curHP == DEFENDING_MON.maxHP) {
                 DEFENDER_TURN_FLAGS.enduring = TRUE;
             }


### PR DESCRIPTION
## 📝 Description

Retains the generation IV effect of Sturdy (immune to OHKO moves) and re-adds the generation V+ effect of surviving hits from 100% health.

## 🎮 Screenshots/Videos

Non-Mold Breaker:

https://github.com/user-attachments/assets/6ebd27b7-8642-4d4c-8b94-1140e14a2c85

Mold Breaker:

https://github.com/user-attachments/assets/9fae8643-f3ce-456b-b33d-7ffdbc9f21df
