### PR TITLE
chore: gitignore knarc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,3 +117,5 @@ compile_commands.json
 # Cheat files
 *.dct
 *.mch
+
+knarc/


### PR DESCRIPTION
## 📝 Description

Adds `/knarc` folder to `.gitignore` to do testing with NARC file extraction