### PR TITLE
Ice Types 1.5x Defence in Hail

### DIFF
--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -6926,6 +6926,11 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
             spDefenseStat = spDefenseStat * 15 / 10;
         }
 
+        if ((fieldConditions & FIELD_CONDITION_HAILING)
+            && (defenderParams.type1 == TYPE_ICE || defenderParams.type2 == TYPE_ICE)) {
+            defenseStat = defenseStat * 15 / 10;
+        }
+
         if ((fieldConditions & FIELD_CONDITION_SUNNY)
             && BattleSystem_CountAbility(battleSys, battleCtx, COUNT_ALIVE_BATTLERS_OUR_SIDE, attacker, ABILITY_FLOWER_GIFT)) {
             attackStat = attackStat * 15 / 10;


### PR DESCRIPTION
## 📝 Description

Updates hail to use generation IX's Snow mechanic of granting a 1.5x defence boost to Pokemon that are part Ice-type.
