### PR TITLE
[MOVE] Reflect and Light Screen Changes

### DIFF
--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -6998,9 +6998,12 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
 
         if ((sideConditions & SIDE_CONDITION_REFLECT) != FALSE
             && criticalMul == 1
-            && MOVE_DATA(move).effect != BATTLE_EFFECT_REMOVE_SCREENS) {
-            if ((battleType & BATTLE_TYPE_DOUBLES)
-                && BattleSystem_CountAliveBattlers(battleSys, battleCtx, TRUE, defender) == 2) {
+            && (
+                MOVE_DATA(move).effect != BATTLE_EFFECT_REMOVE_SCREENS
+                || ((battleCtx->battleMons[defender].statusVolatile & VOLATILE_CONDITION_FORESIGHT) == 0
+                    && Battler_Ability(battleCtx, attacker) != ABILITY_SCRAPPY)
+            )) {
+            if (battleType & BATTLE_TYPE_DOUBLES) {
                 damage = damage * 2 / 3;
             } else {
                 damage /= 2;
@@ -7039,9 +7042,12 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
 
         if ((sideConditions & SIDE_CONDITION_LIGHT_SCREEN) != FALSE
             && criticalMul == 1
-            && MOVE_DATA(move).effect != BATTLE_EFFECT_REMOVE_SCREENS) {
-            if ((battleType & BATTLE_TYPE_DOUBLES)
-                && BattleSystem_CountAliveBattlers(battleSys, battleCtx, TRUE, defender) == 2) {
+            && (
+                MOVE_DATA(move).effect != BATTLE_EFFECT_REMOVE_SCREENS
+                || ((battleCtx->battleMons[defender].statusVolatile & VOLATILE_CONDITION_FORESIGHT) == 0
+                    && Battler_Ability(battleCtx, attacker) != ABILITY_SCRAPPY)
+            )) {
+            if (battleType & BATTLE_TYPE_DOUBLES) {
                 damage = damage * 2 / 3;
             } else {
                 damage /= 2;

--- a/src/battle/battle_script.c
+++ b/src/battle/battle_script.c
@@ -6804,6 +6804,13 @@ static BOOL BtlCmd_TryBreakScreens(BattleSystem *battleSys, BattleContext *battl
     int jumpIfNoScreens = BattleScript_Read(battleCtx);
     int defending = Battler_Side(battleSys, battleCtx->defender);
 
+    if (MON_HAS_TYPE(battleCtx->defender, TYPE_GHOST)) {
+        if (Battler_Ability(battleCtx, battleCtx->attacker) != ABILITY_SCRAPPY && !(battleCtx->battleMons[defending].statusVolatile & VOLATILE_CONDITION_FORESIGHT)) {
+            BattleScript_Iter(battleCtx, jumpIfNoScreens);
+            return FALSE;
+        }
+    }
+
     if ((battleCtx->sideConditionsMask[defending] & SIDE_CONDITION_REFLECT)
         || (battleCtx->sideConditionsMask[defending] & SIDE_CONDITION_LIGHT_SCREEN)) {
         battleCtx->sideConditionsMask[defending] &= ~SIDE_CONDITION_REFLECT;


### PR DESCRIPTION
## 📝 Description

Light Screen and Reflect have received two primary changes past generation IV that this PR fixes:

1. In Doubles, damage is always reduced by 1/3 instead of just 1/2 when only one battler is left on the field.
2. When Brick Break is used against a target that has either Reflect or Light Screen active, and the target is immune to Brick Break, then the screens are not broken.

There is a small bug in this implementation in that in later generations, Reflect/Light Screen in Doubles reduces damage taken by 2732/4096, as opposed to 2703/4096.