### PR TITLE
Ghost-types are not Trapped

### DIFF
--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -3184,6 +3184,7 @@ BOOL Battler_IsTrappedMsg(BattleSystem *battleSys, BattleContext *battleCtx, int
 
     if (itemEffect == HOLD_EFFECT_FLEE
         || (battleType & BATTLE_TYPE_NO_EXPERIENCE)
+        || MON_HAS_TYPE(battler, TYPE_GHOST)
         || Battler_Ability(battleCtx, battler) == ABILITY_RUN_AWAY) {
         return FALSE;
     }

--- a/src/battle/trainer_ai/trainer_ai.c
+++ b/src/battle/trainer_ai/trainer_ai.c
@@ -4010,12 +4010,12 @@ static BOOL TrainerAI_ShouldSwitch(BattleSystem *battleSys, BattleContext *battl
     // This definition is naive: the AI does not consider itself immune to Magnet Pull from an ally,
     // Shadow Tag if it also has Shadow Tag, Arena Trap if it is a Flying-type, or always able to switch
     // if it is holding a Shed Shell.
-    if ((battleCtx->battleMons[battler].statusVolatile & VOLATILE_CONDITION_TRAPPED)
+    if (MON_IS_NOT_TYPE(battler, TYPE_GHOST) && ((battleCtx->battleMons[battler].statusVolatile & VOLATILE_CONDITION_TRAPPED)
         || (battleCtx->battleMons[battler].moveEffectsMask & MOVE_EFFECT_INGRAIN)
-        || BattleSystem_CountAbility(battleSys, battleCtx, COUNT_ALL_BATTLERS_THEIR_SIDE, battler, ABILITY_SHADOW_TAG)
+        || BattleSystem_CountAbility(battleSys, battleCtx, COUNT_ALL_BATTLERS_EXCEPT_ME, battler, ABILITY_SHADOW_TAG)
         || BattleSystem_CountAbility(battleSys, battleCtx, COUNT_ALL_BATTLERS_THEIR_SIDE, battler, ABILITY_ARENA_TRAP)
         || (BattleSystem_CountAbility(battleSys, battleCtx, COUNT_ALL_BATTLERS_EXCEPT_ME, battler, ABILITY_MAGNET_PULL)
-            && MON_HAS_TYPE(battler, TYPE_STEEL))) {
+            && MON_HAS_TYPE(battler, TYPE_STEEL)))) {
         return FALSE;
     }
 


### PR DESCRIPTION
## 📝 Description

Ghost-types cannot be trapped by any means - this is included but not limited to:

- Arena Trap against grounded Ghost-type Pokemon
- The effects of Ingrain
- Magnet Pull if the Ghost-type Pokemon is also part Steel-type
- Shadow Tag

This has some prior work done for it as part of https://github.com/matt-newhall/plat-hack-decomp/pull/6, specifically [here](https://github.com/matt-newhall/plat-hack-decomp/pull/6/files#diff-b60074893fa5c8680c34cfffa294d9edda259f057803a801aa6b182a40ab12d8R5519-R5521). This is actually the main element that means that Ghost-type Pokemon are untrapped - this PR ensures that no message of 'This Pokemon is trapped!' is ever displayed, as well as letting the trainer AI know they are not trapped.

## 🎮 Screenshots/Videos

### Shadow Tag

https://github.com/user-attachments/assets/a920b969-00b6-4793-b45c-a97f1f365d3e

### Ingrain

https://github.com/user-attachments/assets/43338125-bb1f-4afd-b012-6f9343dd7198

### Arena Trap

https://github.com/user-attachments/assets/940c3673-f1ac-43f9-9977-08b8c1398031
