### PR TITLE
[MOVE & ABILITY] Helping Hand, Huge Power, Hustle, Pure Power & Rivalry do not boost confusion self-hit damage

### DIFF
--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -6717,7 +6717,7 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
         movePower *= 2;
     }
 
-    if (battleCtx->turnFlags[attacker].helpingHand) {
+    if (battleCtx->turnFlags[attacker].helpingHand && (!(move == MOVE_STRUGGLE && inPower == 40))) {
         movePower = movePower * 15 / 10;
     }
 

--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -6729,7 +6729,7 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
 
     moveClass = MOVE_DATA(move).class;
 
-    if (attackerParams.ability == ABILITY_HUGE_POWER || attackerParams.ability == ABILITY_PURE_POWER) {
+    if ((attackerParams.ability == ABILITY_HUGE_POWER || attackerParams.ability == ABILITY_PURE_POWER) && (!(move == MOVE_STRUGGLE && inPower == 40))) {
         attackStat = attackStat * 2;
     }
     if (attackerParams.ability == ABILITY_SLOW_START
@@ -6813,7 +6813,7 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
         movePower /= 2;
     }
 
-    if (attackerParams.ability == ABILITY_HUSTLE) {
+    if (attackerParams.ability == ABILITY_HUSTLE && (!(move == MOVE_STRUGGLE && inPower == 40))) {
         attackStat = attackStat * 150 / 100;
     }
     if (attackerParams.ability == ABILITY_GUTS && attackerParams.statusMask) {
@@ -6927,13 +6927,15 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
     if (attackerParams.ability == ABILITY_RIVALRY
         && attackerParams.gender == defenderParams.gender
         && attackerParams.gender != GENDER_NONE
-        && defenderParams.gender != GENDER_NONE) {
+        && defenderParams.gender != GENDER_NONE
+        && (!(move == MOVE_STRUGGLE && inPower == 40))) {
         movePower = movePower * 125 / 100;
     }
     if (attackerParams.ability == ABILITY_RIVALRY
         && attackerParams.gender != defenderParams.gender
         && attackerParams.gender != GENDER_NONE
-        && defenderParams.gender != GENDER_NONE) {
+        && defenderParams.gender != GENDER_NONE
+        && (!(move == MOVE_STRUGGLE && inPower == 40))) {
         movePower = movePower * 75 / 100;
     }
 


### PR DESCRIPTION
## 📝 Description

Negates certain moves and abilities from boosting self-hit damage.

## 💻 Developer Notes

This is a horrible implementation, feel free to do any better than this!
