### PR TITLE
[ABILITY] Immunity, Insomnia, Limber, Magma Armor, Vital Spirit & Water Veil do not heal Status on switch, and activate after items

### DIFF
--- a/src/battle/battle_script.c
+++ b/src/battle/battle_script.c
@@ -9438,8 +9438,7 @@ static BOOL BtlCmd_TryRestoreStatusOnSwitch(BattleSystem *battleSys, BattleConte
         int ability = Pokemon_GetValue(mon, MON_DATA_ABILITY, NULL);
         int status = Pokemon_GetValue(mon, MON_DATA_STATUS_CONDITION, NULL);
 
-        if (battleCtx->battleMons[battler].ability != ABILITY_NATURAL_CURE
-            && Ability_ForbidsStatus(battleCtx, ability, status) == FALSE) {
+        if (battleCtx->battleMons[battler].ability != ABILITY_NATURAL_CURE) {
             BattleScript_Iter(battleCtx, jumpNoStatusRestore);
         }
     } else {


### PR DESCRIPTION
## 📝 Description

Changes to Immunity, Insomnia, Limber, Magma Armor, Vital Spirit and Water Veil:

- When a statused Pokémon with the relevant above ability enters battle, it will be cured of its status (always happened).
- Does not heal a Pokémon of its status when switching out, if relevant (e.g. if a Pokémon with Water Veil was Skill Swapped to have a different Ability, it could be inflicted with burn. When the Pokémon switches out, it no longer cures status on the switch, and can instead heal it when switching back into battle).
- If a Pokémon has a status-curing ability as well as an item that would cure the status (e.g. Immunity + Pecha Berry), the item will activate first. Notably this is only relevant if the Pokémon is already inflicted with status; abilities that provide status immunities _do not let the Pokémon get statused_ (see point 2 as to how this could happen).

## 🎮 Screenshots/Videos
