### PR TITLE
Damage Calculation Adjustment

### DIFF
--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -7001,6 +7001,8 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
         damage /= stageDivisor;
         damage /= 50;
 
+        damage += 2;
+
         if ((attackerParams.statusMask & MON_CONDITION_BURN) && attackerParams.ability != ABILITY_GUTS) {
             damage /= 2;
         }
@@ -7045,6 +7047,8 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
 
         damage /= stageDivisor;
         damage /= 50;
+
+        damage += 2;
 
         if ((sideConditions & SIDE_CONDITION_LIGHT_SCREEN) != FALSE
             && criticalMul == 1
@@ -7101,7 +7105,7 @@ int BattleSystem_CalcMoveDamage(BattleSystem *battleSys,
         damage = damage * 15 / 10;
     }
 
-    return damage + 2;
+    return damage;
 }
 
 int BattleSystem_CalcDamageVariance(BattleSystem *battleSys, BattleContext *battleCtx, int damage)


### PR DESCRIPTION
## 📝 Description

Slight modification to the general damage formula to account for the change in generation V, specifically:

#### Gen IV:

$$
\text{Damage} = \left\lfloor 
  \left\lfloor 
    \left\lfloor \frac{2 \times \text{Level}}{5} + 2 \right\rfloor 
    \times \text{BasePower} \times \frac{\text{Attack}}{\text{Defense}} 
    \div 50 
  \right\rfloor \times \text{Burn} \times \text{Screens} \times \text{IsDoubles} \times \text{Weather} \times \text{FlashFire} + 2 
\right\rfloor \times \text{Modifier}
$$

#### Gen V onwards:

$$
\text{Damage} = \left\lfloor \left\lfloor \frac{\left\lfloor \frac{2 \times \text{Level}}{5} + 2 \right\rfloor \times \text{BasePower} \times \frac{\text{Attack}}{\text{Defense}}}{50} \right\rfloor + 2 \right\rfloor \times \text{Modifier}
$$
