### PR TITLE
[ABILITY] Soundproof Pokemon can now be affected by Heal Bell, Perish Song; other Doubles cases

### DIFF
--- a/asm/macros/btlcmd.inc
+++ b/asm/macros/btlcmd.inc
@@ -1240,4 +1240,10 @@
     .long 224
     .endm
 
+    .macro CheckIsPerishSongAffected battler, jump
+    .long 225
+    .long \battler
+    .long (\jump-.) / 4 - 1
+    .endm
+
     .endif // ASM_BATTLE_SCRIPT_INC

--- a/res/battle/scripts/subscripts/subscript_perish_song_start.s
+++ b/res/battle/scripts/subscripts/subscript_perish_song_start.s
@@ -15,7 +15,7 @@ _000:
 
 _021:
     GetMonBySpeedOrder BTLVAR_MSG_BATTLER_TEMP
-    CheckIgnorableAbility CHECK_NOT_HAVE, BTLSCR_MSG_TEMP, ABILITY_SOUNDPROOF, _037
+    CheckIsPerishSongAffected BTLSCR_MSG_TEMP, _037
     // {0}’s {1} blocks {2}!
     PrintMessage pl_msg_00000368_00689, TAG_NICKNAME_ABILITY_MOVE, BTLSCR_MSG_TEMP, BTLSCR_MSG_TEMP, BTLSCR_MSG_TEMP
     Wait 

--- a/src/battle/battle_io_command.c
+++ b/src/battle/battle_io_command.c
@@ -693,7 +693,7 @@ static void ov16_0225C5E0(BattleSystem *battleSys, BattlerData *param1)
             v4 = Pokemon_GetValue(v1, MON_DATA_ABILITY, NULL);
         }
 
-        if ((v0->unk_02 != 215) || ((v0->unk_02 == 215) && (v4 != ABILITY_SOUNDPROOF))) {
+        if ((v0->unk_02 != 215) || ((v0->unk_02 == 215))) {
             Pokemon_SetValue(v1, MON_DATA_STATUS_CONDITION, (u8 *)&v5);
         }
     }

--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -3573,6 +3573,9 @@ static u16 sSoundMoves[] = {
     MOVE_HYPER_VOICE,
     MOVE_BUG_BUZZ,
     MOVE_CHATTER,
+    MOVE_PERISH_SONG,
+    MOVE_HOWL,
+    MOVE_HEAL_BELL
 };
 
 int BattleSystem_TriggerImmunityAbility(BattleContext *battleCtx, int attacker, int defender)

--- a/src/battle/battle_lib.c
+++ b/src/battle/battle_lib.c
@@ -3623,7 +3623,7 @@ int BattleSystem_TriggerImmunityAbility(BattleContext *battleCtx, int attacker, 
 
     if (Battler_IgnorableAbility(battleCtx, attacker, defender, ABILITY_SOUNDPROOF) == TRUE) {
         for (int i = 0; i < NELEMS(sSoundMoves); i++) {
-            if (sSoundMoves[i] == battleCtx->moveCur) {
+            if (sSoundMoves[i] == battleCtx->moveCur && attacker != defender) {
                 subscript = subscript_blocked_by_soundproof;
                 break;
             }

--- a/src/battle/battle_script.c
+++ b/src/battle/battle_script.c
@@ -5282,12 +5282,8 @@ static BOOL BtlCmd_TryPartyStatusRefresh(BattleSystem *battleSys, BattleContext 
     if (battleCtx->moveCur == MOVE_HEAL_BELL) {
         battleCtx->msgMoveTemp = battleCtx->moveCur;
 
-        if (Battler_Ability(battleCtx, battleCtx->attacker) != ABILITY_SOUNDPROOF) {
             ATTACKING_MON.status = MON_CONDITION_NONE;
             ATTACKING_MON.statusVolatile &= ~VOLATILE_CONDITION_NIGHTMARE;
-        } else {
-            battleCtx->calcTemp |= (SOUNDPROOF_SLOT_1 | NO_PARTNER_SLOT_1);
-        }
 
         if (battleType & BATTLE_TYPE_DOUBLES) {
             int partner = BattleScript_Battler(battleSys, battleCtx, BTLSCR_ATTACKER_PARTNER);

--- a/src/battle/battle_script.c
+++ b/src/battle/battle_script.c
@@ -308,6 +308,7 @@ static BOOL BtlCmd_RefreshMonData(BattleSystem *battleSys, BattleContext *battle
 static BOOL BtlCmd_End(BattleSystem *battleSys, BattleContext *battleCtx);
 static BOOL BtlCmd_IsTailwindWeather(BattleSystem *battleSys, BattleContext *battleCtx);
 static BOOL BtlCmd_CalcTauntTurns(BattleSystem *battleSys, BattleContext *battleCtx);
+static BOOL BtlCmd_CheckIsPerishSongAffected(BattleSystem *battleSys, BattleContext *battleCtx);
 
 static int BattleScript_Read(BattleContext *battleCtx);
 static void BattleScript_Iter(BattleContext *battleCtx, int i);
@@ -569,7 +570,8 @@ static const BtlCmd sBattleCommands[] = {
     BtlCmd_RefreshMonData,
     BtlCmd_End,
     BtlCmd_IsTailwindWeather,
-    BtlCmd_CalcTauntTurns
+    BtlCmd_CalcTauntTurns,
+    BtlCmd_CheckIsPerishSongAffected
 };
 
 BOOL BattleScript_Exec(BattleSystem *battleSys, BattleContext *battleCtx)
@@ -5728,7 +5730,7 @@ static BOOL BtlCmd_TryPerishSong(BattleSystem *battleSys, BattleContext *battleC
     for (int i = 0; i < maxBattlers; i++) {
         if ((battleCtx->battleMons[i].moveEffectsMask & MOVE_EFFECT_PERISH_SONG)
             || battleCtx->battleMons[i].curHP == 0
-            || Battler_IgnorableAbility(battleCtx, battleCtx->attacker, i, ABILITY_SOUNDPROOF) == TRUE) {
+            || (Battler_IgnorableAbility(battleCtx, battleCtx->attacker, i, ABILITY_SOUNDPROOF) == TRUE && (!(battleCtx->battleMons[battleCtx->attacker].personality == battleCtx->battleMons[i].personality)))) {
             ineligibleBattlers++;
         } else {
             battleCtx->battleMons[i].moveEffectsMask |= MOVE_EFFECT_PERISH_SONG;
@@ -8016,6 +8018,41 @@ static BOOL BtlCmd_CheckIgnorableAbility(BattleSystem *battleSys, BattleContext 
             BattleScript_Iter(battleCtx, jump);
             battleCtx->abilityMon = battler;
         }
+    }
+
+    return FALSE;
+}
+
+/**
+ * @brief Checks if Perish Song is used on a valid target
+ *
+ * Inputs:
+ * 1. Input battler (or set of battlers) whose ability should be checked
+ * 2. GoTo distance if a battler in the input set meets the criteria
+ *
+ * Side effects:
+ * - CompareVarToValue any battler matches the criteria, battleCtx->abilityMon will be set
+ * to their identifier.
+ *
+ * @param battleSys
+ * @param battleCtx
+ * @return FALSE
+ */
+static BOOL BtlCmd_CheckIsPerishSongAffected(BattleSystem *battleSys, BattleContext *battleCtx)
+{
+    BattleScript_Iter(battleCtx, 1);
+    int inBattler = BattleScript_Read(battleCtx);
+    int jump = BattleScript_Read(battleCtx);
+
+    int battler = BattleScript_Battler(battleSys, battleCtx, inBattler);
+
+    if (battleCtx->attacker == battler) {
+        BattleScript_Iter(battleCtx, jump);
+        battleCtx->abilityMon = battler;
+    } else if ((Battler_IgnorableAbility(battleCtx, battleCtx->attacker, battler, ABILITY_SOUNDPROOF) == FALSE
+        || battleCtx->battleMons[battler].curHP == 0)) {
+        BattleScript_Iter(battleCtx, jump);
+        battleCtx->abilityMon = battler;
     }
 
     return FALSE;


### PR DESCRIPTION
## 📝 Description

Soundproof has undergone many changes, namely:

1. Inactive Pokémon are always healed by Heal Bell, regardless of if they have Soundproof.
2. Pokémon with Soundproof are no longer immune to their own sound-based moves.
3. Howl is now a sound-based move.
