### PR TITLE
[MOVE] Bind, Clamp, Fire Spin, Magma Storm, Sand Tomb, Whirlpool and Wrap last 4-5 turns and deal 1/8 HP per turn as damage

### DIFF
--- a/res/battle/scripts/subscripts/subscript_bind_start.s
+++ b/res/battle/scripts/subscripts/subscript_bind_start.s
@@ -11,9 +11,9 @@ _001:
     PrintBufferedMessage 
     Wait 
     WaitButtonABTime 30
-    Random 3, 3
+    Random 1, 5
     CheckItemHoldEffect CHECK_NOT_HAVE, BTLSCR_ATTACKER, HOLD_EFFECT_EXTEND_TRAPPING, _024
-    UpdateVar OPCODE_SET, BTLVAR_CALC_TEMP, 0x00000006
+    UpdateVar OPCODE_SET, BTLVAR_CALC_TEMP, 0x00000007
 
 _024:
     UpdateVar OPCODE_LEFT_SHIFT, BTLVAR_CALC_TEMP, 0x0000000D

--- a/src/battle/battle_controller.c
+++ b/src/battle/battle_controller.c
@@ -1490,7 +1490,7 @@ static void BattleController_CheckMonConditions(BattleSystem *battleSys, BattleC
                 battleCtx->battleMons[battler].statusVolatile -= (1 << VOLATILE_CONDITION_BIND_SHIFT);
 
                 if (battleCtx->battleMons[battler].statusVolatile & VOLATILE_CONDITION_BIND) {
-                    battleCtx->hpCalcTemp = BattleSystem_Divide(battleCtx->battleMons[battler].maxHP * -1, 16);
+                    battleCtx->hpCalcTemp = BattleSystem_Divide(battleCtx->battleMons[battler].maxHP * -1, 8);
                     LOAD_SUBSEQ(subscript_bind_effect);
                 } else {
                     LOAD_SUBSEQ(subscript_bind_end);


### PR DESCRIPTION
## 📝 Description

Changes trapping moves to deal 1/8 damage per turn, as opposed to 1/16. It also changes the minimum trapping turns to 4-5, and 6 with a Grip Claw.

NOTE: Grip Claw should last for 7 turns, so in `res/battle/scripts/subscripts/subscript_bind_start.s` you need to change:

```suggestion
-- UpdateVar OPCODE_SET, BTLVAR_CALC_TEMP, 0x00000007
++ UpdateVar OPCODE_SET, BTLVAR_CALC_TEMP, 0x00000008
```

But this causes the defender to be inflicted with Attract to themselves 🤷 
