### PR TITLE
[MOVE] Howl raises the user and allies' Attack stats, unless they have Soundproof or are behind a Substitute. It is also now a sound-based move

### DIFF
--- a/res/battle/moves/howl/data.json
+++ b/res/battle/moves/howl/data.json
@@ -9,7 +9,7 @@
         "type": "BATTLE_EFFECT_ATK_UP",
         "chance": 0
     },
-    "range": "RANGE_USER",
+    "range": "RANGE_USER_SIDE",
     "priority": 0,
     "flags": [
         "MOVE_FLAG_CAN_SNATCH"


### PR DESCRIPTION
## 📝 Description

- Really shaky set of changes to get Howl to activate on all allies.
- Also adds Howl as a sound-based move, meaning that it will not activate on allies with Soundproof.
- Will also not activate on allies behind a Substitute, but does work on allies that are Protected.
- If anyone else is reading this, I'd heavily recommend doing this literally any other way, I'm just getting lazy at this point

## 🎮 Screenshots/Videos

https://github.com/user-attachments/assets/7090bb5e-5da4-4fac-bec8-f2180e371077
