### PR TITLE
Add Natures to Pokemon Trainers

### DIFF
--- a/include/struct_defs/trainer_data.h
+++ b/include/struct_defs/trainer_data.h
@@ -11,8 +11,9 @@
 
 #define TRAINER_MON_FORM_SHIFT 10
 
-#define MAX_TRAINER_ITEMS 4
-#define MAX_IV_SCALE      255
+#define MAX_TRAINER_ITEMS      4
+#define MAX_IV_SCALE           255
+#define TRAINER_MON_NATURE_NONE 0xFF
 
 enum TrainerDataType {
     TRDATATYPE_BASE = 0,
@@ -36,6 +37,7 @@ typedef struct TrainerMonBase {
     u16 level;
     u16 species;
     u16 cbSeal;
+    u16 nature;
 } TrainerMonBase;
 
 typedef struct TrainerMonWithMoves {
@@ -44,6 +46,7 @@ typedef struct TrainerMonWithMoves {
     u16 species;
     u16 moves[LEARNED_MOVES_MAX];
     u16 cbSeal;
+    u16 nature;
 } TrainerMonWithMoves;
 
 typedef struct TrainerMonWithItem {
@@ -52,6 +55,7 @@ typedef struct TrainerMonWithItem {
     u16 species;
     u16 item;
     u16 cbSeal;
+    u16 nature;
 } TrainerMonWithItem;
 
 typedef struct TrainerMonWithMovesAndItem {
@@ -61,6 +65,7 @@ typedef struct TrainerMonWithMovesAndItem {
     u16 item;
     u16 moves[LEARNED_MOVES_MAX];
     u16 cbSeal;
+    u16 nature;
 } TrainerMonWithMovesAndItem;
 
 #endif // POKEPLATINUM_STRUCT_TRAINER_DATA_H

--- a/res/trainers/data/champion_cynthia.json
+++ b/res/trainers/data/champion_cynthia.json
@@ -96,6 +96,7 @@
                 "MOVE_GIGA_IMPACT"
             ],
             "iv_scale": 250,
+            "nature": "NATURE_JOLLY",
             "ball_seal": 0
         }
     ],

--- a/res/trainers/data/elite_four_aaron.json
+++ b/res/trainers/data/elite_four_aaron.json
@@ -24,7 +24,8 @@
                 "MOVE_DOUBLE_TEAM"
             ],
             "iv_scale": 250,
-            "ball_seal": 0
+            "ball_seal": 0,
+            "nature": "NATURE_MODEST"
         },
         {
             "species": "SPECIES_SCIZOR",

--- a/src/trainer_data.c
+++ b/src/trainer_data.c
@@ -211,6 +211,8 @@ static void TrainerData_BuildParty(FieldBattleDTO *dto, int battler, enum HeapID
             }
 
             rnd = (rnd << 8) + genderMod;
+            if (trmon[i].nature != TRAINER_MON_NATURE_NONE)
+                rnd += (trmon[i].nature - (rnd % 25) + 25) % 25;
             ivs = trmon[i].ivScale * MAX_IVS_SINGLE_STAT / MAX_IV_SCALE;
 
             Pokemon_InitWith(mon, species, trmon[i].level, ivs, TRUE, rnd, OTID_NOT_SHINY, 0);
@@ -236,6 +238,8 @@ static void TrainerData_BuildParty(FieldBattleDTO *dto, int battler, enum HeapID
             }
 
             rnd = (rnd << 8) + genderMod;
+            if (trmon[i].nature != TRAINER_MON_NATURE_NONE)
+                rnd += (trmon[i].nature - (rnd % 25) + 25) % 25;
             ivs = trmon[i].ivScale * MAX_IVS_SINGLE_STAT / MAX_IV_SCALE;
 
             Pokemon_InitWith(mon, species, trmon[i].level, ivs, TRUE, rnd, OTID_NOT_SHINY, 0);
@@ -266,6 +270,8 @@ static void TrainerData_BuildParty(FieldBattleDTO *dto, int battler, enum HeapID
             }
 
             rnd = (rnd << 8) + genderMod;
+            if (trmon[i].nature != TRAINER_MON_NATURE_NONE)
+                rnd += (trmon[i].nature - (rnd % 25) + 25) % 25;
             ivs = trmon[i].ivScale * MAX_IVS_SINGLE_STAT / MAX_IV_SCALE;
 
             Pokemon_InitWith(mon, species, trmon[i].level, ivs, TRUE, rnd, OTID_NOT_SHINY, 0);
@@ -292,6 +298,8 @@ static void TrainerData_BuildParty(FieldBattleDTO *dto, int battler, enum HeapID
             }
 
             rnd = (rnd << 8) + genderMod;
+            if (trmon[i].nature != TRAINER_MON_NATURE_NONE)
+                rnd += (trmon[i].nature - (rnd % 25) + 25) % 25;
             ivs = trmon[i].ivScale * MAX_IVS_SINGLE_STAT / MAX_IV_SCALE;
 
             Pokemon_InitWith(mon, species, trmon[i].level, ivs, TRUE, rnd, OTID_NOT_SHINY, 0);

--- a/tools/dataproc/src/trainerproc.c
+++ b/tools/dataproc/src/trainerproc.c
@@ -20,6 +20,7 @@
 #include "constants/pokemon.h"
 #include "generated/ai_flags.h"
 #include "generated/items.h"
+#include "generated/natures.h"
 #include "generated/species.h"
 #include "generated/trainers.h"
 #include "generated/trainer_classes.h"
@@ -169,11 +170,17 @@ Container proc_trainer(datafile_t *df, enum TrainerID trainer) {
         // We always store the maximum possible data, then trim it when packing
         u16 species = dp_u16(dp_lookup(dp_objmemb(party_member, "species"), "Species"));
         u16 form    = dp_u8(dp_objmemb(party_member, "form"));
+        u16 nature = TRAINER_MON_NATURE_NONE;
+        if (dp_hasmemb(party_member, "nature")) {
+            nature = dp_u16(dp_lookup(dp_objmemb(party_member, "nature"), "Nature"));
+        }
+
         trparty.party[i] = (TrainerMonWithMovesAndItem){
             .ivScale = dp_u16(dp_objmemb(party_member, "iv_scale")),
             .level   = dp_u16(dp_objmemb(party_member, "level")),
             .species = (u16)(species | (form << TRAINER_MON_FORM_SHIFT)),
             .cbSeal  = dp_u16(dp_objmemb(party_member, "ball_seal")),
+            .nature  = nature,
         };
 
         if (party_has_items) trparty.party[i].item = dp_u16(dp_lookup(dp_objmemb(party_member, "item"), "Item"));
@@ -410,6 +417,10 @@ static void pack(Container *trainer) {
         copy_size = sizeof(trainer->party.party[i].cbSeal);
         memcpy(p, &trainer->party.party[i].cbSeal, copy_size);
         p += copy_size;
+
+        copy_size = sizeof(trainer->party.party[i].nature);
+        memcpy(p, &trainer->party.party[i].nature, copy_size);
+        p += copy_size;
     }
 
     // TRAINER_NONE has 0 party members, but a non-zero file size in the archive
@@ -432,6 +443,7 @@ static void pre_init(void) {
     dp_regmetang(AIFlag);
     dp_regmetang(Item);
     dp_regmetang(Move);
+    dp_regmetang(Nature);
     dp_regmetang(Species);
     dp_regmetang(TrainerClass);
     dp_regmetang(TrainerMessageType);


### PR DESCRIPTION
## 📝 Description

Adds (optional) nature declaration to trainer Pokemon. Needs testing in DSPRE and setup in external tooling before we progress with this.